### PR TITLE
Improve session dismissal handling for movie cards

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- Add session-based movie dismissal with per-card remove controls and empty state messaging.

--- a/docs/style.css
+++ b/docs/style.css
@@ -78,6 +78,7 @@ div#day-links a:first-of-type {
     padding: 18px;
     color: #222;
     box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+    position: relative;
 }
 
 .movie > div {
@@ -142,6 +143,41 @@ div#day-links a:first-of-type {
     width: 50%;
     flex-shrink: 0;
     max-width: 220px;
+}
+
+.remove-button {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    border: none;
+    background-color: rgba(255, 255, 255, 0.85);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+    color: #555;
+    font-size: 20px;
+    line-height: 1;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.remove-button:hover,
+.remove-button:focus {
+    background-color: #f5f5f5;
+    color: #222;
+    outline: none;
+}
+
+.empty-state {
+    margin: 40px auto;
+    max-width: 600px;
+    text-align: center;
+    color: #666;
+    font-size: 18px;
+    line-height: 1.4;
 }
 
 @media (max-width: 1250px) {


### PR DESCRIPTION
## Summary
- filter dismissed movies before rendering and drive rendering through a reusable `renderApp` helper
- refresh the day navigation after per-card dismissals and show an empty-state message when nothing remains
- add styling for the empty-state message to keep the layout polished
- document the session dismissal improvements in the changelog

## Testing
- manual

------
https://chatgpt.com/codex/tasks/task_e_68e5bb299544832c84ef0d7f48e161ac